### PR TITLE
fix: health check with missing identify dependency

### DIFF
--- a/src/health-check.ts
+++ b/src/health-check.ts
@@ -16,6 +16,7 @@ import { readFile } from 'node:fs/promises'
 import { parseArgs } from 'node:util'
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
+import { identify } from '@libp2p/identify'
 import { kadDHT } from '@libp2p/kad-dht'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { tcp } from '@libp2p/tcp'
@@ -74,7 +75,8 @@ async function tryToDialMaddrOrPeerId (multiaddrOrPeerId: string): Promise<void>
       noise()
     ],
     services: {
-      dht: kadDHT({ clientMode: true })
+      dht: kadDHT({ clientMode: true }),
+      identify: identify()
     }
   })
 


### PR DESCRIPTION
## What's in this PR

- Add identify to fix broken health check

## Reason

Health checks fails because identify was missing
```
Could not dial any of the listening addresses [AggregateError: All promises were rejected] {
  [errors]: [
    UnmetServiceDependenciesError: Service "@libp2p/kad-dht" required capability "@libp2p/identify" but it was not provided by any component, you may need to add additional configuration when creating your node.
        at checkServiceDependencies (file:///app/node_modules/libp2p/dist/src/components.js:101:23)
        at new Libp2p (file:///app/node_modules/libp2p/dist/src/libp2p.js:157:9)
        at createLibp2p (file:///app/node_modules/libp2p/dist/src/index.js:48:18)
        at async tryToDialMaddrOrPeerId (file:///app/dist/src/health-check.js:58:18)
        at async Promise.any (index 0)
        at async tryToDialListeningAddrs (file:///app/dist/src/health-check.js:94:9)
        at async file:///app/dist/src/health-check.js:121:5,
    UnmetServiceDependenciesError: Service "@libp2p/kad-dht" required capability "@libp2p/identify" but it was not provided by any component, you may need to add additional configuration when creating your node.
        at checkServiceDependencies (file:///app/node_modules/libp2p/dist/src/components.js:101:23)
        at new Libp2p (file:///app/node_modules/libp2p/dist/src/libp2p.js:157:9)
        at createLibp2p (file:///app/node_modules/libp2p/dist/src/index.js:48:18)
        at async tryToDialMaddrOrPeerId (file:///app/dist/src/health-check.js:58:18)
        at async Promise.any (index 1)
        at async tryToDialListeningAddrs (file:///app/dist/src/health-check.js:94:9)
        at async file:///app/dist/src/health-check.js:121:5,
    UnmetServiceDependenciesError: Service "@libp2p/kad-dht" required capability "@libp2p/identify" but it was not provided by any component, you may need to add additional configuration when creating your node.
        at checkServiceDependencies (file:///app/node_modules/libp2p/dist/src/components.js:101:23)
        at new Libp2p (file:///app/node_modules/libp2p/dist/src/libp2p.js:157:9)
        at createLibp2p (file:///app/node_modules/libp2p/dist/src/index.js:48:18)
        at async tryToDialMaddrOrPeerId (file:///app/dist/src/health-check.js:58:18)
        at async Promise.any (index 2)
        at async tryToDialListeningAddrs (file:///app/dist/src/health-check.js:94:9)
        at async file:///app/dist/src/health-check.js:121:5,
    UnmetServiceDependenciesError: Service "@libp2p/kad-dht" required capability "@libp2p/identify" but it was not provided by any component, you may need to add additional configuration when creating your node.
        at checkServiceDependencies (file:///app/node_modules/libp2p/dist/src/components.js:101:23)
        at new Libp2p (file:///app/node_modules/libp2p/dist/src/libp2p.js:157:9)
        at createLibp2p (file:///app/node_modules/libp2p/dist/src/index.js:48:18)
        at async tryToDialMaddrOrPeerId (file:///app/dist/src/health-check.js:58:18)
        at async Promise.any (index 3)
        at async tryToDialListeningAddrs (file:///app/dist/src/health-check.js:94:9)
        at async file:///app/dist/src/health-check.js:121:5,
    UnmetServiceDependenciesError: Service "@libp2p/kad-dht" required capability "@libp2p/identify" but it was not provided by any component, you may need to add additional configuration when creating your node.
        at checkServiceDependencies (file:///app/node_modules/libp2p/dist/src/components.js:101:23)
        at new Libp2p (file:///app/node_modules/libp2p/dist/src/libp2p.js:157:9)
        at createLibp2p (file:///app/node_modules/libp2p/dist/src/index.js:48:18)
        at async tryToDialMaddrOrPeerId (file:///app/dist/src/health-check.js:58:18)
        at async Promise.any (index 4)
        at async tryToDialListeningAddrs (file:///app/dist/src/health-check.js:94:9)
        at async file:///app/dist/src/health-check.js:121:5
  ]
}
```