### PR TITLE
fix: only start one libp2p node for healthcheck

### DIFF
--- a/src/health-check.ts
+++ b/src/health-check.ts
@@ -12,125 +12,75 @@
  * - need to execute functionality similar to https://github.com/mxinden/libp2p-lookup/
  * as used by https://github.com/libp2p/rust-libp2p/tree/master/misc/server
  */
-import { readFile } from 'node:fs/promises'
+import { readFileSync } from 'node:fs'
 import { parseArgs } from 'node:util'
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
-import { identify } from '@libp2p/identify'
-import { kadDHT } from '@libp2p/kad-dht'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { tcp } from '@libp2p/tcp'
 import { webSockets } from '@libp2p/websockets'
 import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
-import { createLibp2p, type Libp2p } from 'libp2p'
+import { createLibp2p } from 'libp2p'
 import type { PeerId } from '@libp2p/interface'
 
-async function getMaddrFromPeerId (node: Libp2p, peerId: PeerId): Promise<Multiaddr[]> {
-  /**
-   * if we receive a PeerId (which would be a string because its from command line) we need to do:
-   * * dht lookup
-   * * dial
-   */
-  const resolvedPeer = await node.peerRouting.findPeer(peerId)
-
-  return resolvedPeer.multiaddrs
-}
-
-async function tryToDialMaddrOrPeerId (multiaddrOrPeerId: string): Promise<void> {
-  let multiaddrs: Multiaddr[] = []
-  let peerId = null
-  let maddr: Multiaddr | null = null
-
-  try {
-    maddr = multiaddr(multiaddrOrPeerId)
-    multiaddrs = [maddr]
-  } catch (e) {
-    // don't care about error, try peerId
-    console.error('Could not convert input into multiaddr', e)
-  }
-
-  try {
-    if (maddr == null) {
-      // don't try to parse peerId if we already have a multiaddr, to prevent flooding output with unnecessary errors
-      peerId = peerIdFromString(multiaddrOrPeerId)
-    }
-  } catch (error) {
-    // peer id failed, maybe multiaddr didn't?
-    console.error('Could not convert input into PeerId', error)
-  }
-
-  if (multiaddr == null && peerId == null) {
-    throw new Error('Could not convert input into valid dialable artifact.')
-  }
-
-  const node = await createLibp2p({
-    transports: [
-      webSockets(),
-      tcp()
-    ],
-    streamMuxers: [
-      yamux()
-    ],
-    connectionEncrypters: [
-      noise()
-    ],
-    services: {
-      dht: kadDHT({ clientMode: true }),
-      identify: identify()
-    }
+function readPositional (): PeerId | Multiaddr | undefined {
+  const { positionals } = parseArgs({
+    allowPositionals: true
   })
 
-  if (peerId != null) {
-    multiaddrs = await getMaddrFromPeerId(node, peerId)
+  if (positionals.length === 0) {
+    return
   }
 
-  // if we receive a Multiaddr, dial it immediately
-  const conn = await node.dial(multiaddrs, {
-    onProgress: (evt) => {
-      console.info(evt.type, evt.detail)
-    }
-  })
-  console.info('Successfully dialed server', multiaddrs)
-  // close the connection
-  await conn.close()
+  if (positionals.length > 1) {
+    throw new Error('Multiple peerIds nor multiaddrs are not supported')
+  }
 
-  // shut the node down
-  await node.stop()
+  try {
+    return peerIdFromString(positionals[0])
+  } catch {
+    try {
+      return multiaddr(positionals[0])
+    } catch {}
+  }
 }
 
-async function tryToDialListeningAddrs (): Promise<void> {
-  // read from file
-  const listeningAddrs = await readFile('listening-addrs.txt', 'utf8')
-  const addrs = listeningAddrs.split('\n')
-  console.info('Trying to dial listening addresses:', addrs)
+function readListeningAddrs (): Multiaddr[] {
   try {
-    await Promise.any(addrs.map(async (addr) => tryToDialMaddrOrPeerId(addr)))
-    // it works!
-    process.exit(0)
-  } catch (e) {
-    console.error('Could not dial any of the listening addresses', e)
+    // read from file
+    return readFileSync('listening-addrs.txt', 'utf8')
+      .split('\n')
+      .map(ma => multiaddr(ma))
+  } catch (err) {
+    console.error('Could read listening-addrs.txt', err)
     process.exit(1)
   }
 }
 
-const { positionals } = parseArgs({
-  allowPositionals: true
+// we will use this node to dial the bootstrapper
+const node = await createLibp2p({
+  transports: [
+    webSockets(),
+    tcp()
+  ],
+  streamMuxers: [
+    yamux()
+  ],
+  connectionEncrypters: [
+    noise()
+  ]
 })
 
-if (positionals.length > 1) {
-  throw new Error('Do not support multiple peerIds nor multiaddrs')
-}
+const target: PeerId | Multiaddr | Multiaddr[] = readPositional() ?? readListeningAddrs()
 
-const multiaddrOrPeerId = positionals[0]
+console.info('Trying to dial', target)
 
-if (multiaddrOrPeerId != null) {
-  try {
-    await tryToDialMaddrOrPeerId(multiaddrOrPeerId)
-  } catch (e) {
-    console.error('Could not dial', e)
-    console.info('Trying to dial listening addresses')
-    await tryToDialListeningAddrs()
-  }
-} else {
-  await tryToDialListeningAddrs()
+try {
+  await node.dial(target)
+
+  // it works!
+  process.exit(0)
+} catch (e) {
+  console.error('Could not dial any of the listening addresses', e)
+  process.exit(1)
 }

--- a/src/health-check.ts
+++ b/src/health-check.ts
@@ -13,49 +13,18 @@
  * as used by https://github.com/libp2p/rust-libp2p/tree/master/misc/server
  */
 import { readFileSync } from 'node:fs'
-import { parseArgs } from 'node:util'
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
-import { peerIdFromString } from '@libp2p/peer-id'
 import { tcp } from '@libp2p/tcp'
 import { webSockets } from '@libp2p/websockets'
 import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
 import { createLibp2p } from 'libp2p'
 import type { PeerId } from '@libp2p/interface'
 
-function readPositional (): PeerId | Multiaddr | undefined {
-  const { positionals } = parseArgs({
-    allowPositionals: true
-  })
-
-  if (positionals.length === 0) {
-    return
-  }
-
-  if (positionals.length > 1) {
-    throw new Error('Multiple peerIds nor multiaddrs are not supported')
-  }
-
-  try {
-    return peerIdFromString(positionals[0])
-  } catch {
-    try {
-      return multiaddr(positionals[0])
-    } catch {}
-  }
-}
-
-function readListeningAddrs (): Multiaddr[] {
-  try {
-    // read from file
-    return readFileSync('listening-addrs.txt', 'utf8')
-      .split('\n')
-      .map(ma => multiaddr(ma))
-  } catch (err) {
-    console.error('Could read listening-addrs.txt', err)
-    process.exit(1)
-  }
-}
+// load the addresses the bootstrapper is listening on
+const target: PeerId | Multiaddr | Multiaddr[] = readFileSync('listening-addrs.txt', 'utf8')
+  .split('\n')
+  .map(ma => multiaddr(ma))
 
 // we will use this node to dial the bootstrapper
 const node = await createLibp2p({
@@ -70,8 +39,6 @@ const node = await createLibp2p({
     noise()
   ]
 })
-
-const target: PeerId | Multiaddr | Multiaddr[] = readPositional() ?? readListeningAddrs()
 
 console.info('Trying to dial', target)
 


### PR DESCRIPTION
Updates the health-check script to dial 1+ multiaddrs using a single node instead of 1+ nodes dialing a single multiaddr each.

It'll either used what's passed on the CLI or try to load the `listening-addrs.txt` file.

## Notes & open questions

- The health-check supports dialing Peer IDs as well as multiaddrs, seems unnecessary here.
- Does it really need to support CLI args?  Doesn't look like they're used by Docker.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works