### PR TITLE
fix: handle fatal metrics error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -183,8 +183,15 @@ async function main (): Promise<void> {
 
   const metricsServer = createServer((req, res) => {
     if (req.url === argMetricsPath && req.method === 'GET') {
-      res.writeHead(200, { 'Content-Type': 'text/plain' })
-      void register.metrics().then((metrics) => res.end(metrics))
+      register.metrics()
+        .then((metrics) => {
+          res.writeHead(200, { 'Content-Type': 'text/plain' })
+          res.end(metrics)
+        }, (err) => {
+          console.error('could not read metrics', err)
+          res.writeHead(500, { 'Content-Type': 'text/plain' })
+          res.end('Internal Server Error')
+        })
     } else {
       res.writeHead(404, { 'Content-Type': 'text/plain' })
       res.end('Not Found')


### PR DESCRIPTION
If the metrics promise rejects the process will crash.

Instead, handle the rejection, log the error and return a 500 to prometheus.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works