### PR TITLE
feat: add persistent datastore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN npm ci --quiet
 
 ENV NODE_ENV production
 
-COPY . ./
+COPY src ./src
+COPY tsconfig.json ./
 RUN npm run build
 RUN npm prune --omit=dev
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,8 +21,8 @@ services:
       - NODE_OPTIONS="--inspect=0.0.0.0"
     volumes:
       - ./config.json:/config.json
-      - bootstrapper_datastore:/app/datastore
-    command: node --config /config.json --enable-kademlia --enable-autonat --api-host=0.0.0.0
+      - bootstrapper_datastore:/datastore
+    command: node --config /config.json --enable-kademlia --enable-autonat --api-host=0.0.0.0 --datastore=/datastore
 
   prometheus:
     restart: unless-stopped

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - NODE_OPTIONS="--inspect=0.0.0.0"
     volumes:
       - ./config.json:/config.json
-      - bootstrapper_datastore:/datastore
+      - bootstrapper_datastore:/app/datastore
     command: node --config /config.json --enable-kademlia --enable-autonat --api-host=0.0.0.0
 
   prometheus:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 volumes:
   prometheus_data: {}
   grafana_data: {}
+  bootstrapper_datastore: {}
 
 services:
   bootstrapper:
@@ -20,6 +21,7 @@ services:
       - NODE_OPTIONS="--inspect=0.0.0.0"
     volumes:
       - ./config.json:/config.json
+      - bootstrapper_datastore:/datastore
     command: node --config /config.json --enable-kademlia --enable-autonat --api-host=0.0.0.0
 
   prometheus:

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,11 @@ const options = {
     default: '127.0.0.1',
     type: 'string'
   },
+  datastore: {
+    description: 'The path to the libp2p datastore directory',
+    default: 'datastore',
+    type: 'string'
+  },
   help: {
     description: 'Show help text',
     type: 'boolean'
@@ -102,6 +107,7 @@ const {
   'metrics-port': argMetricsPort,
   'api-port': argApiPort,
   'api-host': argApiHost,
+  datastore: argDatastore,
   help: argHelp
 } = args.values
 
@@ -154,7 +160,7 @@ if (argEnableAutonat === true) {
 }
 
 const node = await createLibp2p({
-  datastore: new LevelDatastore('datastore'),
+  datastore: new LevelDatastore(argDatastore ?? options.datastore.default),
   privateKey,
   addresses: {
     announceFilter: (addrs) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,7 @@ if (argEnableAutonat === true) {
 }
 
 const node = await createLibp2p({
-  datastore: new LevelDatastore('js-libp2p-datastore'),
+  datastore: new LevelDatastore('datastore'),
   privateKey,
   addresses: {
     announceFilter: (addrs) => {


### PR DESCRIPTION
To make DHT lookups faster, add a persistent datastore so we can repopulate the routing tables on startup from previous runs.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works