### PR TITLE
fix: use workflow_run to publish docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,16 +1,13 @@
 name: Publish docker images
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - 'test & maybe release'
+    types:
+      - completed
     branches:
       - main
-  pull_request:
-  workflow_dispatch:
-    inputs:
-      push:
-        description: 'Push to registry'
-        required: false
-        default: 'false'
 
 jobs:
   publish:
@@ -45,6 +42,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: ${{ github.event_name == 'push' || github.event.inputs.push == 'true' }}
+          push: ${{ github.event_name == 'workflow_run' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Run docker after `js-test-and-release.yml` has run so we can publish a version with the correct version number.

Fixes #161

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works