### PR TITLE
feat: add peer-log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,11 @@ const options = {
     default: 'datastore',
     type: 'string'
   },
+  'peer-log': {
+    description: 'Enable logging connected peers and their user agents',
+    default: false,
+    type: 'boolean'
+  },
   help: {
     description: 'Show help text',
     type: 'boolean'
@@ -109,6 +114,7 @@ const {
   'api-port': argApiPort,
   'api-host': argApiHost,
   datastore: argDatastore,
+  'peer-log': argPeerLog,
   help: argHelp
 } = args.values
 
@@ -243,3 +249,29 @@ const waitForPublicInterval = setInterval(() => {
     console.info('Waiting for public listening addresses...')
   }
 }, 1000)
+
+// replicate https://github.com/ipfs/kubo/blob/97527472fe4c037bb897aa2c7d4e0b2243b58f85/plugin/plugins/peerlog/peerlog.go
+if (argPeerLog) {
+  node.addEventListener('peer:connect', (evt) => {
+    console.info(JSON.stringify({
+      level: 'info',
+      ts: new Date().toISOString(),
+      logger: 'plugin/peerlog',
+      caller: 'peerlog/peerlog.go:51',
+      msg: 'connected',
+      peer: evt.detail.toString()
+    }))
+  })
+
+  node.addEventListener('peer:identify', (evt) => {
+    console.info(JSON.stringify({
+      level: 'info',
+      ts: new Date().toISOString(),
+      logger: 'plugin/peerlog',
+      caller: 'peerlog/peerlog.go:56',
+      msg: 'identified',
+      peer: evt.detail.peerId.toString(),
+      agent: evt.detail.agentVersion
+    }))
+  })
+}


### PR DESCRIPTION
To enable the same monitoring as go-libp2p, add a `--peer-log` cli arg.

Fixes #8

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works